### PR TITLE
Follow-up of Highlight new contributors PR

### DIFF
--- a/_data.qmd
+++ b/_data.qmd
@@ -10,12 +10,7 @@ Last updated: `{r} update_time`
 issues, prs = gha.get_all(data, lang)
 
 issues_open = gha.get_open(issues)
-
 prs_open = gha.get_open(prs)
-
-issues_new_open = gha.get_new_contributors_open(issues)
-
-prs_new_open = gha.get_new_contributors_open(prs)
 
 issues_sum = gha.get_summary(issues)
 prs_sum = gha.get_summary(prs)
@@ -70,7 +65,7 @@ dict(
 #### Row 
 ```{r}
 #| title: New contributors
-dt_show_buttons(py$issues)
+dt_show_buttons(py$issues_open)
 ```
 
 
@@ -90,7 +85,7 @@ alt.Chart(issues_sum).mark_bar(cornerRadius=10).encode(
 
 ```{r}
 #| title: All open PRs
-dt_show_buttons(py$prs)
+dt_show_buttons(py$prs_open)
 ```
 
 

--- a/github_data/methods.py
+++ b/github_data/methods.py
@@ -94,7 +94,7 @@ def get_open(df):
     Select issues or pull requests that are still opened from
     the data frame of all issues or pull requests. Only
     relevant information for creating a list of open issues and
-    prs is kept (date and title with url)
+    prs is kept (date, title with url, html url and author_association)
 
     Parameters
     ----------
@@ -109,36 +109,8 @@ def get_open(df):
     df["url_title"] = (
         '<a target="_blank" href="' + df["html_url"] + '">' + df["title"] + "</a>"
     )
-    return df[df.state == "open"][["created_at", "url_title"]]
-
-
-def get_new_contributors_open(df):
-    """
-    Select issues or pull requests that are still open and are created
-    by a new contributor. Only relevant information for creating a list of
-    open issues and prs is kept (date and title with url)
-
-    Parameters
-    ----------
-    df : pa.DataFrame
-        Pandas data frame with all issues or pull requests.
-
-    Returns
-    -------
-    issues : pd.DataFrame
-        Pandas data frame with only issues or prs still opened and created by
-        a new contributor.
-    """
-    df["url_title"] = (
-        '<a target="_blank" href="' + df["html_url"] + '">' + df["title"] + "</a>"
-    )
-    return df[
-        (
-            (df.author_association == "FIRST_TIME_CONTRIBUTOR")
-            | (df.author_association == "NONE")
-        )
-        & (df.state == "open")
-    ][["created_at", "url_title"]]
+    return df[df.state == "open"][["created_at", "url_title",
+                                   "html_url", "author_association"]]
 
 
 def get_summary(df):

--- a/index.qmd
+++ b/index.qmd
@@ -33,7 +33,7 @@ dt_show_buttons <- function(x){
 
   display_data <- x %>%
     mutate(new_contributor = author_association %in% c("NONE", "FIRST_TIME_CONTRIBUTOR")) %>%
-    select(created_at, url_title, new_contributor)
+    select(created_at, url_title, html_url, new_contributor)
 
   selected_rows <- which(display_data$new_contributor == TRUE)
   DT::datatable(

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ requests==2.32.3
 rpds-py==0.18.1
 six==1.16.0
 toolz==0.12.1
+typing_extensions==4.12.2
 tzdata==2024.1
 urllib3==2.2.2


### PR DESCRIPTION
This is a follow-up of https://github.com/thisisnic/arrowdash/pull/21

- it uses open issues and prs data for the table output
- adds `html_url` column to the table output
- cleans up Python methods